### PR TITLE
No acos

### DIFF
--- a/include/PointInPolygon.h
+++ b/include/PointInPolygon.h
@@ -19,6 +19,8 @@ class PointInPolygon {
 
   bool pointInPolygon(Point &point);
 
+  static bool isRayInSector(RayType &a, RayType &b, RayType &ray);
+
   virtual ~PointInPolygon();
 
  private:

--- a/include/Vector2D.h
+++ b/include/Vector2D.h
@@ -16,6 +16,8 @@ class Vector2D {
 
   double arccos() const;
 
+  void normalize();
+
   T dot(const Vector2D &other) const;
 
   bool operator==(const Vector2D &rhs) const;

--- a/include/impl/Vector2D.cpp
+++ b/include/impl/Vector2D.cpp
@@ -45,7 +45,7 @@ template<typename T>
 void Vector2D<T>::normalize() {
   double _length = this->length();
   x = (T)((double) x / _length);
-  y = (T)((double) y / _length)
+  y = (T)((double) y / _length);
 }
 
 template<typename T>

--- a/include/impl/Vector2D.cpp
+++ b/include/impl/Vector2D.cpp
@@ -42,6 +42,13 @@ double Vector2D<T>::arccos() const {
 }
 
 template<typename T>
+void Vector2D<T>::normalize() {
+  double _length = this->length();
+  x = (T)((double) x / _length);
+  y = (T)((double) y / _length)
+}
+
+template<typename T>
 bool Vector2D<T>::compareVector2D(const Vector2D <T> &a, const Vector2D <T> &b) {
   return (a.x == b.x) ? a.y < b.y : a.x < b.x;
 }

--- a/src/concave2DPointCloud.cpp
+++ b/src/concave2DPointCloud.cpp
@@ -86,7 +86,7 @@ void display(Points &_points, Points &hull, QGraphicsScene *scene) {
 int main(int argc, char *argv[]) {
   QApplication a(argc, argv);
 
-  const int num_points = 2500;
+  const int num_points = 4500;
 
   auto _points = generatePoints(num_points, 200.0);
 

--- a/test/pointInPolygonTests.cpp
+++ b/test/pointInPolygonTests.cpp
@@ -2,6 +2,7 @@
 #include <include/PointInPolygon.h>
 
 using Point = Vector2D<int>;
+using RayType = Vector2D<double>;
 
 TEST(PointInPolygon, AngleMeasureTest) {
   Point ray = Point(1, 0);
@@ -14,20 +15,19 @@ TEST(PointInPolygon, AngleMeasureTest) {
   double num = -0.99014577103682988;
   std::cout << "acos(-0.99014577103682988) = " << std::acos(num);
 
-  Vector2D<double> ra = Vector2D<double>(1.0, 0.1);
-  Vector2D<double> vec = Vector2D<double>(-98.0, -24.0);
+  RayType ra = RayType(1.0, 0.1);
+  RayType vec = RayType(-98.0, -24.0);
   double val = ra.dot(vec) / ra.length() / vec.length();\
-    std::cout << "\n\n";
+  std::cout << "\n\n";
 
   std::cout << "val is " << val << "\n";
   std::cout << "acos(val) = " << std::acos(val);
-
   std::cout << "\n\n";
 
   std::vector<Point> polyLine = {Point(-4, -4), Point(0, 4), Point(4, 0)};
   PointInPolygon pipCalc = PointInPolygon(polyLine);
 
-  std::cout << pipCalc.angleBetween(ra, vec) << "\n";
+  //std::cout << pipCalc.angleBetween(ra, vec) << "\n";
 }
 
 TEST(PointInPolygon, TriangleTest) {
@@ -40,6 +40,16 @@ TEST(PointInPolygon, TriangleTest) {
 
   ASSERT_FALSE(pipCalc.pointInPolygon(query_point_outside));
   ASSERT_TRUE(pipCalc.pointInPolygon(query_point_inside));
+}
+
+TEST(PointInPolygon, isRayInSectorTest) {
+
+  // test isRayInSector function
+  RayType a = RayType(-0.70046, -0.71368);
+  RayType b = RayType(-0.406138, 0.913811);
+  RayType ray = RayType(1.0, 0.0);
+
+  ASSERT_FALSE(PointInPolygon::isRayInSector(a, b, ray));
 }
 
 TEST(PointInPolygon, PointsNotInShape) {


### PR DESCRIPTION
The problem of determining whether the ray cast from the query point crosses a given edge is equivalent to determining if the ray direction as a unit vector is contained in the sector bounded by two other unit vectors, namely unit vectors constructed from edge endpoints relative to the query point. Initially I chose to solve this later problem geometrically by computing the angle ( length) of the curve between the unit vectors through the ray direction, also a unit vector. If angle > PI then the ray does NOT lie between the two unit vectors and the ray cast from the query point does NOT cross the given edge. While totally correct, I wanted to answer the between unit vectors question by using orientation instead of depending on acos(). 

New Approach:
* embed start_vec && end_vec && ray_direction into S^1 in the Z=1 plane of R^3. 
* compute the normal of embedded start_vec && end_vec.
* compare the normal to ray_direction.